### PR TITLE
docs(README): fix installing pytodoist

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ too.):
 
 ```bash
 $ pip install -r requirements.txt
+$ pip install pytodoist --upgrade
 ```
 
 Next, copy the `config.sample.yml` to `config.yml`, and edit it. (There are helpful


### PR DESCRIPTION
I know that there is a comment in the `index.py` file, but I think until the issue is resolved you should add this to the readme. Thanks for the great tool!